### PR TITLE
Feat/try more images when links are dead

### DIFF
--- a/src/utils/fetch-and-write-image.js
+++ b/src/utils/fetch-and-write-image.js
@@ -30,7 +30,8 @@ const fetchAndWriteImage = async ({ url, directory }) => {
         return fileName
       },
       {
-        retries: 5,
+        retries: 1000,
+        factor: 1,
         onRetry: (error, attemptNumber) => {
           // try grabbing a new image from our image dataset
           const { url: newUrl } = sampleSize(fullImageDataset, 1)[0]

--- a/src/utils/fetch-and-write-image.js
+++ b/src/utils/fetch-and-write-image.js
@@ -40,7 +40,7 @@ const fetchAndWriteImage = async ({ url, directory }) => {
           console.log(`trying ${newUrl} instead`)
           imageUrl = newUrl
 
-          if (attemptNumber === 5) {
+          if (attemptNumber === 1000) {
             console.log(directory)
             console.log(url)
             console.error(error)


### PR DESCRIPTION
It looks like there are more dead images in the dataset than anticipated, this should help temporarily before I move all the images to google cloud